### PR TITLE
docs: adding codeowners, code of conduct, etc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,18 @@
+
+
+# Subject:
+# <type>: <short summary>
+#   │            │
+#   │            └─⫸ Summary in present tense. Not capitalised. No period at the end.
+#   │   
+#   │
+#   └─⫸ Commit Type: build|docs|feat|fix|perf|refactor|revert|test
+# 
+# Body:
+# <detailed description of changes made in the commit> (wrap at 72 characters)
+# 
+# Footer:
+# <any additional information, such as references or issue numbers>
+#
+# See CONTRIBUTING.md for more details on commit message format.
+#

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in the repo.
+
+* @ukhsa-collaboration/org-standards-admins

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# Code of conduct
+
+Contributors to this repository are expected to follow the Contributor Covenant Code of Conduct, and those working within Government are also expected to follow the Civil Service Code.
+
+## Civil Service Code
+
+The [Civil Service Code](https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code).
+
+## Contributor Covenant Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+### Our Standards
+
+Examples of behaviour that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behaviour by participants include:
+
+- The use of sexualised language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behaviour and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behaviour.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviours that they deem inappropriate, threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at <codeofconduct@ukhsa.gov.uk>. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+// TODO

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # standards-development
-Development standards for engineering teams
+
+Development standards for engineering teams.
+
+// TODO
+
+## Contributing
+
+We welcome contributions to improve these guidelines. Please read our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get involved.
+
+## Licence
+
+Unless stated otherwise, the codebase is released under [the MIT License][mit].
+This covers both the codebase and any sample code in the documentation.
+
+The documentation is [&copy; Crown copyright][copyright] and available under the terms
+of the [Open Government 3.0][ogl] licence.
+
+## Contact
+
+TODO
+
+[mit]: LICENCE
+[copyright]: https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/
+[ogl]: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/


### PR DESCRIPTION
Initial commit of code owners etc.  Mostly ported over from [ukhsa-collaboration/api-guidelines](https://github.com/ukhsa-collaboration/api-guidelines).