### PR TITLE
feat: add dependabot group support for commitlint packages

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -11,4 +11,4 @@ rules:
     'revert',
     'test'
   ]]
-  scope-empty: [0, 'never']
+  scope-empty: [1, 'always']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,26 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+    groups:
+      commitlint:
+        applies-to: version-updates
+        dependency-type: "development"
+        patterns:
+          - "@commitlint*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "engines": {
         "node": "22",
-        "npm": "10"
+        "npm": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/ukhsa-collaboration/standards-development",
   "license": "MIT",
   "engines": {
-    "npm": "10",
+    "npm": ">=10",
     "node": "22"
   },
   "devDependencies": {


### PR DESCRIPTION
@commitlint/cli and @commitlint/config-conventional should be updated together

- update commitlintrc.yaml to prevent the usage of scope in commit message
- update package.json engines to allow newer npm versions